### PR TITLE
[FEAT] Enhance Markdown Callouts and Add Rehype-Callouts Integration

### DIFF
--- a/_markdowns/blog/bypassing-certificate-pinning-android-api-sdk.mdx
+++ b/_markdowns/blog/bypassing-certificate-pinning-android-api-sdk.mdx
@@ -128,7 +128,7 @@ To install the Android app, you can use the following command:
 adb install <path-to-apk-file>
 ```
 
-> **NOTE:**
+> [!important]
 > You need to have [Android SDK](https://developer.android.com/studio) installed on your machine.
 > You can install adb using [Homebrew](https://brew.sh/) on macOS via `brew install android-platform-tools`.
 

--- a/_markdowns/blog/modular-openapi-first-code-generation.mdx
+++ b/_markdowns/blog/modular-openapi-first-code-generation.mdx
@@ -312,16 +312,13 @@ I use this scripts to start Mockoon, local-cors-proxy and Swagger UI.
 }
 ```
 
-Note 1
-
+> [!note] Note 1
 > I use `concurrently` to run multiple commands at the same time. You can install it via `pnpm install -D concurrently`.
 
-Note 2
-
+> [!note] Note 2
 > I use `http-server` to serve Swagger UI. You can install it via `pnpm install -D http-server`.
 
-Note 3
-
+> [!note] Note 3
 > I use `swagger-ui-dist` to serve Swagger UI. You can install it via `pnpm install -D swagger-ui-dist`.
 > In script `preview:swagger` I copy `openapi.generated.yaml` to `node_modules/swagger-ui-dist/index.yaml`
 > you will need type `/index.yaml` inside Swagger UI and click `Explore` to see the documentation.

--- a/_markdowns/blog/unlock-tf-i60-g1-modem.mdx
+++ b/_markdowns/blog/unlock-tf-i60-g1-modem.mdx
@@ -31,7 +31,7 @@ curl http://192.168.1.1/login.cgi_post --data "submit_button=traceroute_test&sub
 ```bash
 telnet 192.168.1.1
 ```
-
+> [!important]
 > If you are using Windows, you need to enable the telnet client from the control panel.
 > Go to `Control Panel > Programs > Turn Windows features on or off` and enable the `Telnet Client`.
 > Then you can run the `telnet` command.
@@ -47,13 +47,13 @@ mount -o remount,rw /
 vi /opt/nvram/nvram.cfg
 ```
 
-Quick `vi` commands:
+> [!note]- Quick `vi` commands:
 > You can use the `i` key to enter the insert mode and the `Esc` key to exit the insert mode.
 > To save and exit, press `Shift + :` and type `wq` then press `Enter`.
 > use the `dd` command to delete a line.
 > use the `u` command to undo the last change.
 
-Note:
+> [!tip]
 > Exclude the `-` sign and add the `+` sign to the beginning of the line to add a new line.
 > These are for showing the changes, you don't need to add them to the file.
 
@@ -108,7 +108,7 @@ sqns_connection_fastScan=1^M
 vi /etc/init.d/rc1
 ```
 
-Note:
+> [!tip]
 > Exclude the `+` sign to the beginning of the line to add a new line.
 > These are for showing the changes, you don't need to add them to the file.
 

--- a/_markdowns/blog/using-steam-api-with-nextjs.mdx
+++ b/_markdowns/blog/using-steam-api-with-nextjs.mdx
@@ -25,7 +25,8 @@ npx create-next-app --ts
 
 Now, you need to get a Steam API key. You can get it from [here](https://steamcommunity.com/dev/apikey).
 
-> NOTE: If you haven't bought any game from Steam, you can't get a Steam API key.
+> [!important]
+> If you haven't bought any game from Steam, you can't get a Steam API key.
 
 ## Get Your Steam ID
 
@@ -121,6 +122,7 @@ export const getNowPlaying = async (): Promise<GetPlayerSummariesResponse> => {
 Now, we need to create an API route to get the current playing game.
 Create a file called `app/api/steam/now-playing.ts` and add the following code to it.
 
+> [!note]
 > I'm using NextJS app router to create API routes.
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "reading-time": "^1.5.0",
     "rehype-accessible-emojis": "^0.3.2",
     "rehype-autolink-headings": "^7.1.0",
+    "rehype-callouts": "^2.1.0",
     "rehype-code-titles": "^1.0.3",
     "rehype-pretty-code": "^0.14.1",
     "rehype-slug": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       rehype-autolink-headings:
         specifier: ^7.1.0
         version: 7.1.0
+      rehype-callouts:
+        specifier: ^2.1.0
+        version: 2.1.0
       rehype-code-titles:
         specifier: ^1.0.3
         version: 1.2.0
@@ -7405,6 +7408,10 @@ packages:
 
   rehype-autolink-headings@7.1.0:
     resolution: {integrity: sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==}
+
+  rehype-callouts@2.1.0:
+    resolution: {integrity: sha512-Als/wlYpXg2Rs0p/yofrkSH6IQzn1xh6cvBC5BHy5JVT3lGlzUvVT8wOyVqCEgf8Eun6cQ3f47rLLoaiyLkP0w==}
+    engines: {node: ^18.0.0 || >=20.0.0}
 
   rehype-code-titles@1.2.0:
     resolution: {integrity: sha512-bSr2YJ0GHbHFarUNDZ3VpcGi9HqjLNrA9Lj3nuyox2aGGLhN53dFP2WJtPRnnRqU/vpbCatIgOYxEvWP1YYKrw==}
@@ -17054,6 +17061,14 @@ snapshots:
       hast-util-heading-rank: 3.0.0
       hast-util-is-element: 3.0.0
       unified: 11.0.5
+      unist-util-visit: 5.0.0
+
+  rehype-callouts@2.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-html: 2.0.3
+      hast-util-is-element: 3.0.0
+      hastscript: 9.0.1
       unist-util-visit: 5.0.0
 
   rehype-code-titles@1.2.0:

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,6 @@
 @import "tailwindcss";
+@import "rehype-callouts/theme/github";
+
 @plugin "@tailwindcss/typography";
 @plugin "tailwindcss-hocus";
 

--- a/velite.config.ts
+++ b/velite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "velite";
 import { rehypeAccessibleEmojis } from "rehype-accessible-emojis";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
+import rehypeCallouts from "rehype-callouts";
 import rehypeCodeTitles from "rehype-code-titles";
 import rehypePrettyCode from "rehype-pretty-code";
 import rehypeSlug from "rehype-slug";
@@ -23,6 +24,7 @@ export default defineConfig({
       rehypeAccessibleEmojis,
       rehypeToc,
       rehypePrettyCode,
+      rehypeCallouts,
       [
         rehypeAutolinkHeadings,
         {


### PR DESCRIPTION
This update introduces standardized callout syntax (`[!important]`, `[!note]`, `[!tip]`) across multiple blog posts, replacing the previous ad-hoc note formatting. The changes improve consistency and readability in documentation.  

Key modifications include:  
- Added `rehype-callouts` package to handle callout rendering  
- Updated global CSS to include callout styles  
- Modified Velite config to integrate the callouts plugin  
- Standardized note formatting in 4 different blog posts  

The changes address the need for a more maintainable and visually consistent way to display notes, warnings, and tips in documentation. Testing should verify that all callouts render correctly with proper styling in both development and production environments.  

Affected files include MDX blog posts, package configuration, and styling files. The integration may affect other markdown processing pipelines, though no breaking changes are expected.